### PR TITLE
[libc] add missing header deps to getauxval

### DIFF
--- a/libc/src/sys/auxv/linux/CMakeLists.txt
+++ b/libc/src/sys/auxv/linux/CMakeLists.txt
@@ -15,4 +15,5 @@ add_entrypoint_object(
     libc.src.fcntl.open
     libc.src.unistd.read
     libc.src.unistd.close
+    libc.include.sys.auxv
 )


### PR DESCRIPTION
`getauxval` depends on `libc.include.sys.auxv`